### PR TITLE
Dev/3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ---
 
 ### How to clone
+
 `git clone --recursive https://github.com/GlitchedPolygons/pwcrypt.git`
 
 ### How to use the library
@@ -25,18 +26,23 @@ If you don't want to use git submodules, you can also start vendoring a specific
 Check out the [API docs](https://glitchedpolygons.github.io/pwcrypt/files.html) or the [`pwcrypt.h`](https://github.com/GlitchedPolygons/pwcrypt/blob/master/include/pwcrypt.h) header file to find out how to call the encrypt/decrypt functions in C.
 
 #### Note for Windows users
+
 The [`build.bat`](https://github.com/GlitchedPolygons/pwcrypt/blob/master/build.bat) script needs to be run with the _"x64 Native Tools Command Prompt for Visual Studio 2019"_ as an admin, NOT with the standard cmd.exe! 
 
 #### Linking
+
 If you use [CMake](https://cmake.org) you can just `add_subdirectory(path_to_submodule)` and then `target_link_libraries(your_project PRIVATE pwcrypt)` inside your CMakeLists.txt file.
 
 ### How to use the CLI
+
 The pwcrypt command line interface works using the following (relatively rigid) sequence of arguments:
 
 - Mode ('e' for encrypting, 'd' for decrypting)
 - Input text (string to encrypt or decrypt)
 - Password (string to encrypt the input with)
 - [Optional params for encryption]
+
+`pwcrypt_cli {e|d} {input} {password} [--time-cost=INT] [--memory-cost=INT] [--parallelism=INT] [--compression=INT] [--algorithm=aes256-gcm|chachapoly] [--file=OUTPUT_FILE_PATH]`
 
 #### Encrypting
 
@@ -66,3 +72,20 @@ Append `--algorithm=chachapoly` at the end to use the [ChaCha20-Poly1305](https:
 #### Decrypting
 
 `pwcrypt_cli d "EwAAAAQAAAAAAAQAAgAAAFYjNGlNEnNMn5VtyW5hvxnKhdk9i" "Decryption Password 123 !!!"`
+
+### Files instead of strings
+
+The pwcrypt CLI supports encrypting/decrypting files instead of strings too: <p>
+Append the argument `--file="/usr/some/output/filepath.bin"` containing the **output** file path,
+and the result will be written into a file instead of printing it out to the console.
+In this case, the `{input}` text argument will be treated not as a string to encrypt, but as the input path of the file to encrypt/decrypt.
+
+* Example:
+
+<pre>
+pwcrypt_cli e "/home/someuser/secret.png" \
+     "Extremely Safe Encryption 1337 PW" \
+     --file="/home/someuser/enrypted-secret.dat" \
+     --compression=0 \
+     --algorithm=chachapoly
+</pre>

--- a/README.md
+++ b/README.md
@@ -89,3 +89,7 @@ pwcrypt_cli e "/home/someuser/secret.png" \
      --compression=0 \
      --algorithm=chachapoly
 </pre>
+
+Please keep in mind: <br>
+The output string path is **definitive**: there will be no asking whether it's ok to overwrite existing files or not. 
+So make sure to only confirm commands that you know won't cause loss of some files!

--- a/include/pwcrypt.h
+++ b/include/pwcrypt.h
@@ -71,12 +71,12 @@ static const uint8_t EMPTY64[64] = {
 /**
  * Current version of the used pwcrypt library.
  */
-#define PWCRYPT_VERSION 300
+#define PWCRYPT_VERSION 310
 
 /**
  * Current version of the used pwcrypt library (nicely-formatted string).
  */
-#define PWCRYPT_VERSION_STR "3.0.0"
+#define PWCRYPT_VERSION_STR "3.1.0"
 
 /**
  * Default chunksize to use for compressing and decompressing buffers.
@@ -153,6 +153,11 @@ static const uint8_t EMPTY64[64] = {
  * Error code for when decompressing data fails (ccrush lib failure)..
  */
 #define PWCRYPT_ERROR_DECOMPRESSION_FAILURE 8000
+
+/**
+ * Error code for failures while handling files.
+ */
+#define PWCRYPT_ERROR_FILE_FAILURE 9000
 
 /**
  * Picks the smaller of two numbers.

--- a/src/main.c
+++ b/src/main.c
@@ -17,6 +17,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <mbedtls/platform_util.h>
+
 #include "pwcrypt.h"
 
 static const char HELP_TEXT[] = "\n"
@@ -26,7 +28,7 @@ static const char HELP_TEXT[] = "\n"
                                 "Encrypt and decrypt strings using passwords. \n"
                                 "The strings are compressed and then encrypted by deriving a symmetric encryption key from the password using Argon2. \n\n"
                                 "Usage: \n\n"
-                                "pwcrypt_cli {e|d} {input} {password} [--time-cost=INT] [--memory-cost=INT] [--parallelism=INT] [--algorithm=aes256-gcm|chachapoly] \n\n"
+                                "pwcrypt_cli {e|d} {input} {password} [--time-cost=INT] [--memory-cost=INT] [--parallelism=INT] [--compression=INT] [--algorithm=aes256-gcm|chachapoly] [--file=OUTPUT_FILE_PATH]\n\n"
                                 "Examples: \n\n"
                                 "-- Encrypting \n\n"
                                 "  pwcrypt_cli e \"My string to encrypt.\" \"SUPER-safe Password123_!\" \n\n"
@@ -58,75 +60,127 @@ int main(const int argc, const char* argv[])
     const char* password = argv[3];
     const size_t password_length = strlen(password);
 
+    int r = -1;
+
+    uint8_t file = 0;
+
+    uint8_t* input = (uint8_t*)text;
+    size_t input_length = text_length;
+
+    FILE* input_file = NULL;
+
+    uint8_t* output = NULL;
+    size_t output_length = 0;
+
+    FILE* output_file = NULL;
+
+    uint32_t compression = 8;
+    uint32_t algo_id = PWCRYPT_ALGO_ID_AES256_GCM;
+    uint32_t cost_t = 0, cost_m = 0, parallelism = 0;
+
     if (mode_length != 1)
     {
         fprintf(stderr, PWCRYPT_INVALID_ARGS_ERROR_MSG);
-        return PWCRYPT_ERROR_INVALID_ARGS;
+        r = PWCRYPT_ERROR_INVALID_ARGS;
+        goto exit;
     }
 
-    int r = -1;
-    uint8_t* output = NULL;
-    size_t output_length = 0;
+    for (int i = 4; i < argc; i++)
+    {
+        const char* arg = argv[i];
+
+        if (strlen(arg) == 2 && strncmp(arg, "--", 2) == 0)
+        {
+            break;
+        }
+
+        if (strncmp("--time-cost=", arg, 12) == 0)
+        {
+            cost_t = strtol(arg + 12, NULL, 10);
+            continue;
+        }
+
+        if (strncmp("--memory-cost=", arg, 14) == 0)
+        {
+            cost_m = strtol(arg + 14, NULL, 10);
+            continue;
+        }
+
+        if (strncmp("--parallelism=", arg, 14) == 0)
+        {
+            parallelism = strtol(arg + 14, NULL, 10);
+            continue;
+        }
+
+        if (strncmp("--compression=", arg, 14) == 0)
+        {
+            compression = strtol(arg + 14, NULL, 10);
+            continue;
+        }
+
+        if (strncmp("--file=", arg, 7) == 0)
+        {
+            file = 1;
+
+            input_file = fopen(text, "r");
+            if (input_file == NULL)
+            {
+                fprintf(stderr, "pwcrypt: Failure to open file \"%s\"\n", text);
+                r = PWCRYPT_ERROR_FILE_FAILURE;
+                goto exit;
+            }
+
+            fseek(input_file, 0, SEEK_END);
+            input_length = ftell(input_file);
+            rewind(input_file);
+
+            input = malloc(input_length);
+            if (input == NULL)
+            {
+                fprintf(stderr, "pwcrypt: OUT OF MEMORY!\n");
+                r = PWCRYPT_ERROR_OOM;
+                goto exit;
+            }
+
+            if (input_length != fread(input, sizeof(uint8_t), input_length, input_file))
+            {
+                fprintf(stderr, "pwcrypt: Failure to read file \"%s\"\n", text);
+                r = PWCRYPT_ERROR_FILE_FAILURE;
+                goto exit;
+            }
+
+            output_file = fopen(arg + 7, "wb");
+            if (output_file == NULL)
+            {
+                fprintf(stderr, "pwcrypt: Failure to create output file %s\n", arg + 7);
+                r = PWCRYPT_ERROR_FILE_FAILURE;
+                goto exit;
+            }
+
+            continue;
+        }
+
+        if (strncmp("--algorithm=", arg, 12) == 0)
+        {
+            // Currently, this is OK since there are only 2 algos that have the IDs 0 and 1.
+            // But at a later point, it would def. make sense to have a decent control block here for extracting algo ID from the CLI args.
+            algo_id = (uint32_t)(strncmp("chachapoly", arg + 12, 10) == 0);
+            continue;
+        }
+    }
 
     switch (*mode)
     {
         case 'e': {
-            uint32_t compression = 8;
-            uint32_t algo_id = PWCRYPT_ALGO_ID_AES256_GCM;
-            uint32_t cost_t = 0, cost_m = 0, parallelism = 0;
-
-            for (int i = 4; i < argc; i++)
-            {
-                const char* arg = argv[i];
-
-                if (strlen(arg) == 2 && strncmp(arg, "--", 2) == 0)
-                {
-                    break;
-                }
-
-                if (strncmp("--time-cost=", arg, 12) == 0)
-                {
-                    cost_t = strtol(arg + 12, NULL, 10);
-                    continue;
-                }
-
-                if (strncmp("--memory-cost=", arg, 14) == 0)
-                {
-                    cost_m = strtol(arg + 14, NULL, 10);
-                    continue;
-                }
-
-                if (strncmp("--parallelism=", arg, 14) == 0)
-                {
-                    parallelism = strtol(arg + 14, NULL, 10);
-                    continue;
-                }
-
-                if (strncmp("--compression=", arg, 14) == 0)
-                {
-                    compression = strtol(arg + 14, NULL, 10);
-                    continue;
-                }
-
-                if (strncmp("--algorithm=", arg, 12) == 0)
-                {
-                    // Currently, this is OK since there are only 2 algos that have the IDs 0 and 1.
-                    // But at a later point, it would def. make sense to have a decent control block here for extracting algo ID from the CLI args.
-                    algo_id = (uint32_t)(strncmp("chachapoly", arg + 12, 10) == 0);
-                    continue;
-                }
-            }
-
-            r = pwcrypt_encrypt((uint8_t*)text, text_length, compression, (uint8_t*)password, password_length, cost_t, cost_m, parallelism, algo_id, &output, &output_length, 1);
+            r = pwcrypt_encrypt(input, input_length, compression, (uint8_t*)password, password_length, cost_t, cost_m, parallelism, algo_id, &output, &output_length, (uint32_t)(!file));
             if (r != 0)
             {
                 fprintf(stderr, "pwcrypt: Encryption failed!\n");
             }
-
             break;
         }
         case 'd': {
-            r = pwcrypt_decrypt((uint8_t*)text, text_length, (uint8_t*)password, password_length, &output, &output_length);
+            r = pwcrypt_decrypt(input, input_length, (uint8_t*)password, password_length, &output, &output_length);
             if (r != 0)
             {
                 fprintf(stderr, "pwcrypt: Decryption failed!\n");
@@ -135,16 +189,60 @@ int main(const int argc, const char* argv[])
         }
         default: {
             fprintf(stderr, PWCRYPT_INVALID_ARGS_ERROR_MSG);
-            return PWCRYPT_ERROR_INVALID_ARGS;
+            r = PWCRYPT_ERROR_INVALID_ARGS;
+            goto exit;
         }
     }
 
-    if (r == 0 && output)
+    if (r == 0 && output != NULL)
     {
-        fprintf(stdout, "%s\n", output);
-        memset(output, 0x00, output_length);
+        if (file)
+        {
+            if (output_length != fwrite(output, sizeof(uint8_t), output_length, output_file))
+            {
+                fprintf(stderr, "pwcrypt: Encryption failed! Couldn't write all %zu bytes into the output file...\n", output_length);
+                r = PWCRYPT_ERROR_FILE_FAILURE;
+            }
+        }
+        else
+        {
+            fprintf(stdout, "%s\n", output);
+        }
+    }
+
+exit:
+    if (input_file != NULL)
+    {
+        fclose(input_file);
+        mbedtls_platform_zeroize(&input_file, sizeof(FILE*));
+    }
+
+    if (output_file != NULL)
+    {
+        fclose(output_file);
+        mbedtls_platform_zeroize(&output_file, sizeof(FILE*));
+    }
+
+    if (file && input != NULL)
+    {
+        mbedtls_platform_zeroize(input, input_length);
+        free(input);
+    }
+
+    if (output != NULL)
+    {
+        mbedtls_platform_zeroize(output, output_length);
         free(output);
     }
 
-    return r;
+    mbedtls_platform_zeroize(&file, sizeof(uint8_t));
+    mbedtls_platform_zeroize(&input, sizeof(uint8_t*));
+    mbedtls_platform_zeroize(&output, sizeof(uint8_t*));
+    mbedtls_platform_zeroize(&compression, sizeof(uint32_t));
+    mbedtls_platform_zeroize(&algo_id, sizeof(uint32_t));
+    mbedtls_platform_zeroize(&cost_t, sizeof(uint32_t));
+    mbedtls_platform_zeroize(&cost_m, sizeof(uint32_t));
+    mbedtls_platform_zeroize(&parallelism, sizeof(uint32_t));
+
+    return (r);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -120,8 +120,6 @@ int main(const int argc, const char* argv[])
 
         if (strncmp("--file=", arg, 7) == 0)
         {
-            file = 1;
-
             input_file = fopen(text, "r");
             if (input_file == NULL)
             {
@@ -130,6 +128,7 @@ int main(const int argc, const char* argv[])
                 goto exit;
             }
 
+            file = 1;
             fseek(input_file, 0, SEEK_END);
             input_length = ftell(input_file);
             rewind(input_file);

--- a/src/main.c
+++ b/src/main.c
@@ -201,6 +201,7 @@ int main(const int argc, const char* argv[])
             {
                 fprintf(stderr, "pwcrypt: Encryption failed! Couldn't write all %zu bytes into the output file...\n", output_length);
                 r = PWCRYPT_ERROR_FILE_FAILURE;
+                goto exit;
             }
         }
         else

--- a/src/pwcrypt.c
+++ b/src/pwcrypt.c
@@ -528,7 +528,7 @@ exit:
     mbedtls_platform_zeroize(&argon2_cost_t, sizeof(uint32_t));
     mbedtls_platform_zeroize(&argon2_cost_m, sizeof(uint32_t));
     mbedtls_platform_zeroize(&argon2_parallelism, sizeof(uint32_t));
-    
+
     mbedtls_platform_zeroize(key, sizeof(key));
     mbedtls_platform_zeroize(iv, sizeof(iv));
     mbedtls_platform_zeroize(tag, sizeof(tag));

--- a/src/pwcrypt.c
+++ b/src/pwcrypt.c
@@ -329,23 +329,23 @@ exit:
     mbedtls_gcm_free(&aes_ctx);
     mbedtls_chachapoly_free(&chachapoly_ctx);
 
-    memset(key, 0x00, sizeof(key));
+    mbedtls_platform_zeroize(key, sizeof(key));
 
     if (output_buffer != NULL)
     {
-        memset(output_buffer, 0x00, output_buffer_length);
+        mbedtls_platform_zeroize(output_buffer, output_buffer_length);
         free(output_buffer);
     }
 
     if (output_buffer_base64 != NULL)
     {
-        memset(output_buffer_base64, 0x00, output_buffer_base64_size);
+        mbedtls_platform_zeroize(output_buffer_base64, output_buffer_base64_size);
         free(output_buffer_base64);
     }
 
     if (input_buffer != NULL)
     {
-        memset(input_buffer, 0x00, input_buffer_length);
+        mbedtls_platform_zeroize(input_buffer, input_buffer_length);
         free(input_buffer);
     }
 
@@ -522,20 +522,20 @@ exit:
     mbedtls_chachapoly_free(&chachapoly_ctx);
     pwcrypt_version_number = 0, pwcrypt_algo_id = 0, pwcrypt_compressed = 0, argon2_version_number = 0, argon2_cost_t = 0, argon2_cost_m = 0, argon2_parallelism = 0;
 
-    memset(key, 0x00, sizeof(key));
-    memset(iv, 0x00, sizeof(iv));
-    memset(tag, 0x00, sizeof(tag));
-    memset(salt, 0x00, sizeof(salt));
+    mbedtls_platform_zeroize(key, sizeof(key));
+    mbedtls_platform_zeroize(iv, sizeof(iv));
+    mbedtls_platform_zeroize(tag, sizeof(tag));
+    mbedtls_platform_zeroize(salt, sizeof(salt));
 
     if (input != NULL)
     {
-        memset(input, 0x00, input_length);
+        mbedtls_platform_zeroize(input, input_length);
         free(input);
     }
 
     if (decrypted != NULL)
     {
-        memset(decrypted, 0x00, decrypted_length);
+        mbedtls_platform_zeroize(decrypted, decrypted_length);
         free(decrypted);
     }
 

--- a/src/pwcrypt.c
+++ b/src/pwcrypt.c
@@ -520,8 +520,15 @@ exit:
 
     mbedtls_gcm_free(&aes_ctx);
     mbedtls_chachapoly_free(&chachapoly_ctx);
-    pwcrypt_version_number = 0, pwcrypt_algo_id = 0, pwcrypt_compressed = 0, argon2_version_number = 0, argon2_cost_t = 0, argon2_cost_m = 0, argon2_parallelism = 0;
 
+    mbedtls_platform_zeroize(&pwcrypt_version_number, sizeof(uint32_t));
+    mbedtls_platform_zeroize(&pwcrypt_algo_id, sizeof(uint32_t));
+    mbedtls_platform_zeroize(&pwcrypt_compressed, sizeof(uint32_t));
+    mbedtls_platform_zeroize(&argon2_version_number, sizeof(uint32_t));
+    mbedtls_platform_zeroize(&argon2_cost_t, sizeof(uint32_t));
+    mbedtls_platform_zeroize(&argon2_cost_m, sizeof(uint32_t));
+    mbedtls_platform_zeroize(&argon2_parallelism, sizeof(uint32_t));
+    
     mbedtls_platform_zeroize(key, sizeof(key));
     mbedtls_platform_zeroize(iv, sizeof(iv));
     mbedtls_platform_zeroize(tag, sizeof(tag));


### PR DESCRIPTION
* Use MbedTLS's own per-platform zeroize function instead of the standard memset for cleaning up/wiping memory inside encrypt/decrypt functions.
* Added support for files instead of string arguments in the CLI.